### PR TITLE
Fix horizontal scroll on small screens

### DIFF
--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -9,6 +9,7 @@ body {
     background: var(--marrom-escuro);
     color: var(--bege);
     min-height: 100vh;
+    overflow-x: hidden;
 }
 
 header {

--- a/src/css/responsive.css
+++ b/src/css/responsive.css
@@ -80,7 +80,8 @@
 /* 📱 Ajustes específicos para telas muito pequenas (até 440px) */
 @media (max-width: 440px) {
   body {
-    width: 120%;
+    width: 100%;
+    overflow-x: hidden;
   }
 
   .formatos ul {


### PR DESCRIPTION
## Summary
- set body width to 100% in narrow breakpoint
- hide horizontal overflow globally

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684ed30af17c83319eaaf05c9c7b6d1f